### PR TITLE
chore: confirm that errors do not merge (exp-fail, exp closed PR)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,9 @@ load("@//lib:pkgbuild.bzl", "pkgbuild_tars")
 # Test this payload with:
 #     bazel build //:actions-runner-tar && tar tzf bazel-bin/actions-runner-tar.tar
 # TODO: remove .dll files for smaller payload?
+bok bokbok
+
+
 pkg_tar(
     name = "actions-runner-tar",
     mode = "0755",


### PR DESCRIPTION
This PR is a quick check to ensure that bad PRs do not merge in the very-permissive current mergebot config.  I expect this PR to actually fail and require close-not-merge.