### PR TITLE
fix: track releases using multitool

### DIFF
--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -22,6 +22,14 @@
     "binaries": [
       {
         "kind": "archive",
+        "url": "https://github.com/theoremlp/multitool/releases/download/v0.9.0/multitool-x86_64-unknown-linux-gnu.tar.xz",
+        "file": "multitool-x86_64-unknown-linux-gnu/multitool",
+        "sha256": "34dc5968dad458a4050ebde58e484ebb7c624a119e4031347683eeb80922e6df",
+        "os": "linux",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "archive",
         "url": "https://github.com/theoremlp/multitool/releases/download/v0.9.0/multitool-aarch64-apple-darwin.tar.xz",
         "file": "multitool-aarch64-apple-darwin/multitool",
         "sha256": "8f5e0cd033b0fcc128c762f8d527110433523da378619cecf40e91c1df5c0686",


### PR DESCRIPTION
Fix #44 by providing a `multitool` binary for `ubuntu-latest`