### PR TITLE
fix: correct secret identifier to update PRs

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -43,7 +43,8 @@ jobs:
       - name: Commit
         id: commit
         env:
-          GITHUB_TOKEN: ${{ secrets.GHPAT_CNP_CNB }}
+          # GH_TOKEN for GH command
+          GH_TOKEN: ${{ secrets.GHPAT_CNP_CNB }}
           BRANCH_NAME: "chore/update-multitool-lockfile"
         run: |
           if [[ -n "$(git diff "$LOCKFILE")" ]]


### PR DESCRIPTION
https://github.com/shipitshipit/macos-runner/actions/runs/15357592106/job/43219909003 showed that the `GITHUB_TOKEN` was having no effect:

```
[chore/update-multitool-lockfile 2aa1bf4] Update Multitool Versions
 1 file changed, 4 insertions(+), 4 deletions(-)
remote: Permission to shipitshipit/macos-runner.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/shipitshipit/macos-runner/': The requested URL returned error: 403
```

By identifying the token as `GH_TOKEN` -- looked-for by the `gh command, the proper ID should be enabled, unblocking creation of a new PR.