### PR TITLE
fix: swap back GH_TOKEN for the actual pr create

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -46,8 +46,8 @@ jobs:
         id: commit
         env:
           # GH_TOKEN for GH command
-          #GH_TOKEN: ${{ secrets.GHPAT_CNP_CNB }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GHPAT_CNP_CNB }}
+          #GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: "chore/update-multitool-lockfile"
         run: |


### PR DESCRIPTION
```
To https://github.com/shipitshipit/macos-runner
 * [new branch]      chore/update-multitool-lockfile -> chore/update-multitool-lockfile
pr create
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
Error: Process completed with exit code 1.
```

"Just fix the frikken Hyper Drive!"