### PR TITLE
fix: set update PRs to automerge

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -64,6 +64,7 @@ jobs:
               git push origin "${BRANCH_NAME}" -f
               echo "pr create"
               gh pr create --fill --label "dependencies" >> "$GITHUB_STEP_SUMMARY"
+              gh pr merge --squash --auto >> "$GITHUB_STEP_SUMMARY"
           else
               echo "Nothing to commit"
           fi


### PR DESCRIPTION
A final automation in an auto-PR update workflow would be to permit the PR to auto merge when cleanly built.